### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub's official curriculum. Part of the GitHub Certifications program that helps with college applications.",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
Adds the "GitHub Skills" activity to the school's activity signup system, resolving the urgent student request and supporting the school's partnership with GitHub.

## Changes
- Added "GitHub Skills" activity to the activities list in `src/app.py`
- Set schedule: Wednesdays, 3:30 PM - 4:30 PM
- Set capacity: 25 participants
- Included description emphasizing connection to GitHub Certifications program

## Resolves
Fixes #6: Missing Activity: GitHub Skills

## Timeline
This addresses the time-sensitive registration deadline mentioned in the issue (closing by end of week).

## Testing
The activity will be available through:
- The `/activities` endpoint (returns all activities)
- The activity signup page at `/static/index.html`
- Students can register using the `/activities/{activity_name}/signup` endpoint